### PR TITLE
Code cleanup

### DIFF
--- a/bin/Debugger.Sample/Debugger.Sample.cpp
+++ b/bin/Debugger.Sample/Debugger.Sample.cpp
@@ -424,7 +424,7 @@ int _cdecl wmain(int argc, wchar_t* argv[])
         // Now set the execution context as being the current one on this thread.
         IfFailError(JsSetCurrentContext(context), L"failed to set current context.");
 
-        if (debugProtocolHandler)
+        if (debugProtocolHandler && arguments.breakOnNextLine)
         {
             std::cout << "Waiting for debugger to connect..." << std::endl;
             IfFailError(debugProtocolHandler->WaitForDebugger(), L"failed to wait for debugger");

--- a/doc/debug-companion.md
+++ b/doc/debug-companion.md
@@ -162,8 +162,8 @@ CHAKRA_API JsDebugServiceCreate(JsDebugService* service);
 /// <returns>The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.</returns>
 CHAKRA_API JsDebugServiceDestroy(JsDebugService service);
 
-/// <summary>Register a handler instance with this service.</summary>
-/// <param name="service">The service instance to register with.</param>
+/// <summary>Register a handler instance with a given instance.</summary>
+/// <param name="service">The instance to register with.</param>
 /// <param name="id">The ID of the handler (it must be unique).</param>
 /// <param name="handler">The handler instance.</param>
 /// <param name="breakOnNextLine">Indicates whether to break on the next line of code.</param>
@@ -174,20 +174,20 @@ CHAKRA_API JsDebugServiceRegisterHandler(
     JsDebugProtocolHandler handler,
     bool breakOnNextLine);
 
-/// <summary>Unregister a handler instance from this service.</summary>
-/// <param name="service">The service instance to unregister from.</param>
+/// <summary>Unregister a handler instance from a given instance.</summary>
+/// <param name="service">The instance to unregister from.</param>
 /// <param name="id">The ID of the handler to unregister.</param>
 /// <returns>The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.</returns>
 CHAKRA_API JsDebugServiceUnregisterHandler(JsDebugService service, const char* id);
 
 /// <summary>Start listening on a given port.</summary>
-/// <param name="service">The service instance to listen with.</param>
+/// <param name="service">The instance to listen with.</param>
 /// <param name="port">The port number to listen on.</param>
 /// <returns>The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.</returns>
 CHAKRA_API JsDebugServiceListen(JsDebugService service, uint16_t port);
 
 /// <summary>Stop listening and close any connections.</summary>
-/// <param name="service">The service instance to close.</param>
+/// <param name="service">The instance to close.</param>
 /// <returns>The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.</returns>
 CHAKRA_API JsDebugServiceClose(JsDebugService service);
 ```

--- a/lib/Debugger.Protocol/StringUtil.cpp
+++ b/lib/Debugger.Protocol/StringUtil.cpp
@@ -6,6 +6,7 @@
 #include "StringUtil.h"
 #include "protocol\Protocol.h"
 
+#include <cassert>
 #include <sstream>
 
 //
@@ -117,5 +118,18 @@ namespace JsDebug
 
             return parseJSONCharacters(json.characters16(), static_cast<int>(json.length()));
         }
+    } // namespace protocol
+
+    StringBufferImpl::StringBufferImpl(String16&)
+    {
+        // TODO: Implement this when it gets hit.
+        assert(false);
     }
-}
+
+    std::unique_ptr<StringBufferImpl> StringBufferImpl::adopt(String16&)
+    {
+        // TODO: Implement this when it gets hit.
+        assert(false);
+        return nullptr;
+    }
+} // namespace JsDebug

--- a/lib/Debugger.Protocol/StringUtil.h
+++ b/lib/Debugger.Protocol/StringUtil.h
@@ -7,7 +7,6 @@
 
 #include "Common.h"
 
-#include <cassert>
 #include <memory>
 
 //
@@ -54,18 +53,9 @@ namespace JsDebug
     class StringBufferImpl : public StringBuffer
     {
     public:
-        static std::unique_ptr<StringBufferImpl> adopt(String16& s)
-        {
-            // TODO: Implement this when it gets hit.
-            assert(false);
-            return nullptr;
-        }
+        static std::unique_ptr<StringBufferImpl> adopt(String16& s);
 
     private:
-        explicit StringBufferImpl(String16& s)
-        {
-            // TODO: Implement this when it gets hit.
-            assert(false);
-        }
+        explicit StringBufferImpl(String16& s);
     };
 }

--- a/lib/Debugger.ProtocolHandler/ChakraCore.Debugger.ProtocolHandler.vcxproj
+++ b/lib/Debugger.ProtocolHandler/ChakraCore.Debugger.ProtocolHandler.vcxproj
@@ -224,6 +224,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="TranslateExceptionToJsErrorCode.h" />
     <ClInclude Include="ConsoleImpl.h" />
     <ClInclude Include="Debugger.h" />
     <ClInclude Include="DebuggerBreak.h" />
@@ -260,6 +261,7 @@
     <ClCompile Include="DebuggerRegExp.cpp" />
     <ClCompile Include="DebuggerScript.cpp" />
     <ClCompile Include="ErrorHelpers.cpp" />
+    <ClCompile Include="JsPersistent.cpp" />
     <ClCompile Include="PropertyHelpers.cpp" />
     <ClCompile Include="ProtocolHandler.cpp" />
     <ClCompile Include="ProtocolHelpers.cpp" />

--- a/lib/Debugger.ProtocolHandler/ChakraCore.Debugger.ProtocolHandler.vcxproj.filters
+++ b/lib/Debugger.ProtocolHandler/ChakraCore.Debugger.ProtocolHandler.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClInclude Include="DebuggerContext.h">
       <Filter>Debugger</Filter>
     </ClInclude>
+    <ClInclude Include="TranslateExceptionToJsErrorCode.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Debugger.cpp">
@@ -123,6 +126,9 @@
     </ClCompile>
     <ClCompile Include="DebuggerContext.cpp">
       <Filter>Debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="JsPersistent.cpp">
+      <Filter>Helpers</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/lib/Debugger.ProtocolHandler/Debugger.cpp
+++ b/lib/Debugger.ProtocolHandler/Debugger.cpp
@@ -41,9 +41,9 @@ namespace JsDebug
             void* state = nullptr;
             IfJsErrorThrow(JsDiagStopDebugging(m_runtime, &state));
         }
-        catch (const std::exception& e)
+        catch (...)
         {
-            std::cerr << e.what() << std::endl;
+            // Don't allow the exception to propagate.
         }
     }
 

--- a/lib/Debugger.ProtocolHandler/DebuggerContext.cpp
+++ b/lib/Debugger.ProtocolHandler/DebuggerContext.cpp
@@ -7,6 +7,8 @@
 #include "DebuggerContext.h"
 #include "ErrorHelpers.h"
 
+#include <cassert>
+
 namespace JsDebug
 {
     DebuggerContext::Scope::Scope(const DebuggerContext& context)
@@ -16,7 +18,7 @@ namespace JsDebug
         m_previousContext = currentContext;
 
         JsContextRef newContext = context.m_context.Get();
-        IfJsErrorThrow(JsSetCurrentContext(context.m_context.Get()));
+        IfJsErrorThrow(JsSetCurrentContext(newContext));
         m_currentContext = newContext;
     }
 

--- a/lib/Debugger.ProtocolHandler/JsPersistent.cpp
+++ b/lib/Debugger.ProtocolHandler/JsPersistent.cpp
@@ -1,0 +1,101 @@
+//---------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//---------------------------------------------------------------------------------------------------
+
+#include "stdafx.h"
+#include "JsPersistent.h"
+
+namespace JsDebug
+{
+    JsPersistent::JsPersistent()
+        : JsPersistent(JS_INVALID_REFERENCE)
+    {
+    }
+
+    JsPersistent::JsPersistent(JsValueRef value)
+        : m_value(value)
+    {
+        if (m_value != JS_INVALID_REFERENCE)
+        {
+            IfJsErrorThrow(JsAddRef(m_value, nullptr));
+        }
+    }
+
+    JsPersistent::~JsPersistent()
+    {
+        try
+        {
+            if (m_value != JS_INVALID_REFERENCE)
+            {
+                JsErrorCode err = JsNoError;
+                err = JsRelease(m_value, nullptr);
+
+                // If the host has already cleared the context, release will fail. Get the context of the object, set
+                // it temporarily, release the reference, then clear the context again.
+                if (err == JsErrorNoCurrentContext)
+                {
+                    JsContextRef objContext = JS_INVALID_REFERENCE;
+                    IfJsErrorThrow(JsGetContextOfObject(m_value, &objContext));
+                    IfJsErrorThrow(JsSetCurrentContext(objContext));
+
+                    err = JsRelease(m_value, nullptr);
+
+                    IfJsErrorThrow(JsSetCurrentContext(JS_INVALID_REFERENCE));
+                }
+
+                IfJsErrorThrow(err);
+            }
+        }
+        catch (...)
+        {
+            // Don't allow the exception to propagate.
+        }
+    }
+
+    JsPersistent::JsPersistent(const JsPersistent& other)
+        : JsPersistent()
+    {
+        JsPersistent temp(other.m_value);
+        std::swap(*this, temp);
+    }
+
+    JsPersistent::JsPersistent(JsPersistent&& other)
+        : JsPersistent()
+    {
+        std::swap(m_value, other.m_value);
+    }
+
+    JsPersistent& JsPersistent::operator=(JsPersistent&& other)
+    {
+        std::swap(m_value, other.m_value);
+
+        return *this;
+    }
+
+    JsPersistent& JsPersistent::operator=(const JsPersistent& other)
+    {
+        JsPersistent temp(other);
+        std::swap(*this, temp);
+
+        return *this;
+    }
+
+    JsPersistent& JsPersistent::operator=(const JsValueRef& other)
+    {
+        JsPersistent temp(other);
+        std::swap(*this, temp);
+
+        return *this;
+    }
+
+    bool JsPersistent::IsEmpty() const
+    {
+        return m_value == JS_INVALID_REFERENCE;
+    }
+
+    JsValueRef JsPersistent::Get() const
+    {
+        return m_value;
+    }
+}

--- a/lib/Debugger.ProtocolHandler/JsPersistent.h
+++ b/lib/Debugger.ProtocolHandler/JsPersistent.h
@@ -13,80 +13,19 @@ namespace JsDebug
     class JsPersistent
     {
     public:
-        JsPersistent()
-            : JsPersistent(JS_INVALID_REFERENCE)
-        {
-        }
+        JsPersistent();
+        JsPersistent(JsValueRef value);
+        ~JsPersistent();
 
-        JsPersistent(JsValueRef value)
-            : m_value(value)
-        {
-            if (m_value != JS_INVALID_REFERENCE)
-            {
-                IfJsErrorThrow(JsAddRef(m_value, nullptr));
-            }
-        }
+        JsPersistent(const JsPersistent& other);
+        JsPersistent(JsPersistent&& other);
 
-        ~JsPersistent()
-        {
-            try
-            {
-                if (m_value != JS_INVALID_REFERENCE)
-                {
-                    IfJsErrorThrow(JsRelease(m_value, nullptr));
-                }
-            }
-            catch (const std::exception& e)
-            {
-                std::cerr << e.what() << std::endl;
-            }
-        }
+        JsPersistent& operator=(JsPersistent&& other);
+        JsPersistent& operator=(const JsPersistent& other);
+        JsPersistent& operator=(const JsValueRef& other);
 
-        JsPersistent(const JsPersistent& other)
-            : JsPersistent()
-        {
-            JsPersistent temp(other.m_value);
-            std::swap(*this, temp);
-        }
-
-        JsPersistent(JsPersistent&& other)
-            : JsPersistent()
-        {
-            std::swap(m_value, other.m_value);
-        }
-
-        JsPersistent& operator=(JsPersistent&& other)
-        {
-            std::swap(m_value, other.m_value);
-
-            return *this;
-        }
-
-        JsPersistent& operator=(const JsPersistent& other)
-        {
-            JsPersistent temp(other);
-            std::swap(*this, temp);
-
-            return *this;
-        }
-
-        JsPersistent& operator=(const JsValueRef& other)
-        {
-            JsPersistent temp(other);
-            std::swap(*this, temp);
-
-            return *this;
-        }
-
-        bool IsEmpty() const
-        {
-            return m_value == JS_INVALID_REFERENCE;
-        }
-
-        JsValueRef Get() const
-        {
-            return m_value;
-        }
+        bool IsEmpty() const;
+        JsValueRef Get() const;
 
     private:
         JsValueRef m_value;

--- a/lib/Debugger.ProtocolHandler/TranslateExceptionToJsErrorCode.h
+++ b/lib/Debugger.ProtocolHandler/TranslateExceptionToJsErrorCode.h
@@ -1,0 +1,48 @@
+//---------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//---------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "ErrorHelpers.h"
+#include <ChakraCore.h>
+
+namespace JsDebug
+{
+    template<class Func>
+    JsErrorCode TranslateExceptionToJsErrorCode(Func func)
+    {
+        JsErrorCode err = JsNoError;
+
+        try
+        {
+            func();
+        }
+        catch (const JsErrorException& e)
+        {
+            err = e.code();
+        }
+        catch (...)
+        {
+            err = JsErrorFatal;
+        }
+
+        return err;
+    }
+
+    template<class Class, class Handle, class Func>
+    JsErrorCode TranslateExceptionToJsErrorCode(Handle handle, Func func)
+    {
+        if (handle == nullptr)
+        {
+            return JsErrorInvalidArgument;
+        }
+
+        auto obj = reinterpret_cast<Class>(handle);
+
+        return TranslateExceptionToJsErrorCode([&]() -> void {
+            func(obj);
+        });
+    }
+}

--- a/lib/Debugger.ProtocolHandler/stdafx.h
+++ b/lib/Debugger.ProtocolHandler/stdafx.h
@@ -10,7 +10,6 @@
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 
 #include <array>
-#include <cassert>
 #include <cstdint>
 #include <exception>
 #include <iostream>

--- a/lib/Debugger.Service/ChakraDebugService.h
+++ b/lib/Debugger.Service/ChakraDebugService.h
@@ -20,8 +20,8 @@ CHAKRA_API JsDebugServiceCreate(JsDebugService* service);
 /// <returns>The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.</returns>
 CHAKRA_API JsDebugServiceDestroy(JsDebugService service);
 
-/// <summary>Register a handler instance with this service.</summary>
-/// <param name="service">The service instance to register with.</param>
+/// <summary>Register a handler instance with a given instance.</summary>
+/// <param name="service">The instance to register with.</param>
 /// <param name="id">The ID of the handler (it must be unique).</param>
 /// <param name="handler">The handler instance.</param>
 /// <param name="breakOnNextLine">Indicates whether to break on the next line of code.</param>
@@ -32,19 +32,19 @@ CHAKRA_API JsDebugServiceRegisterHandler(
     JsDebugProtocolHandler handler,
     bool breakOnNextLine);
 
-/// <summary>Unregister a handler instance from this service.</summary>
-/// <param name="service">The service instance to unregister from.</param>
+/// <summary>Unregister a handler instance from a given instance.</summary>
+/// <param name="service">The instance to unregister from.</param>
 /// <param name="id">The ID of the handler to unregister.</param>
 /// <returns>The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.</returns>
 CHAKRA_API JsDebugServiceUnregisterHandler(JsDebugService service, const char* id);
 
 /// <summary>Start listening on a given port.</summary>
-/// <param name="service">The service instance to listen with.</param>
+/// <param name="service">The instance to listen with.</param>
 /// <param name="port">The port number to listen on.</param>
 /// <returns>The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.</returns>
 CHAKRA_API JsDebugServiceListen(JsDebugService service, uint16_t port);
 
 /// <summary>Stop listening and close any connections.</summary>
-/// <param name="service">The service instance to close.</param>
+/// <param name="service">The instance to close.</param>
 /// <returns>The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.</returns>
 CHAKRA_API JsDebugServiceClose(JsDebugService service);


### PR DESCRIPTION
* Fixed JsRelease failure if the context has already been cleared
* Added wrappers to the API surface to catch/convert exceptions
* Removed writes to `cout`/`cerr`
* Moved `cassert` includes next to their usages