### PR TITLE
Avoid static constant initialization in header

### DIFF
--- a/lib/Debugger.Protocol/String16.cpp
+++ b/lib/Debugger.Protocol/String16.cpp
@@ -19,6 +19,8 @@ namespace JsDebug
         const char c_ErrorInvalidIntegerCharacters[] = "String is not a valid integer or contains non-integer characters";
     }
 
+    const size_t String16::kNotFound = std::basic_string<UChar>::npos;
+
     String16::String16()
     {
     }

--- a/lib/Debugger.Protocol/String16.h
+++ b/lib/Debugger.Protocol/String16.h
@@ -19,7 +19,7 @@ namespace JsDebug
     class String16
     {
     public:
-        static const size_t kNotFound = std::basic_string<UChar>::npos;
+        static const size_t kNotFound;
 
         String16();
         String16(const UChar* str, size_t length);

--- a/lib/Debugger.Protocol/StringUtil.cpp
+++ b/lib/Debugger.Protocol/StringUtil.cpp
@@ -17,6 +17,8 @@ namespace JsDebug
 {
     namespace protocol
     {
+        const size_t StringUtil::kNotFound = String::kNotFound;
+
         String StringUtil::substring(const String& s, size_t pos, size_t len)
         {
             return s.substring(pos, len);

--- a/lib/Debugger.Protocol/StringUtil.h
+++ b/lib/Debugger.Protocol/StringUtil.h
@@ -25,7 +25,7 @@ namespace JsDebug
         class StringUtil
         {
         public:
-            static const size_t kNotFound = String::kNotFound;
+            static const size_t kNotFound;
 
             static String substring(const String& s, size_t pos, size_t len);
 


### PR DESCRIPTION
This change avoid a build error with nmake: ``` stringutil.h(28): error C2131: expression did not evaluate to a constant```.  I'm not clear why it is generating the error, but changing the code to initialize the value in the source file avoids the error.