### PR TITLE
Setting exceptions in native code

### DIFF
--- a/bin/Debugger.Sample/test.js
+++ b/bin/Debugger.Sample/test.js
@@ -1,18 +1,47 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//
+// Sample ECMAScript code for exercising the debugger sample. It's not meant to instruct actual usage of the library.
+//
+
 if (typeof host === "undefined") {
+  // Shims for running under Node.js.
   global.host = {
+    "arguments": process.argv,
     echo: console.log,
-    "arguments": process.argv
+    throw: () => { /* no-op on Node.js. */ }
   };
 }
 
+// Print the arguments that the script received.
 for (const arg of host.arguments) {
-    host.echo(`Found arg: ${arg}`);
+  host.echo(`Found arg: ${arg}`);
 }
 
-function doStuff() {
+function testScriptThrow() {
+  try {
+    throw { foo: 4, bar: [1, 2, 3] };
+  } catch (e) {
+    host.echo(e);
+  }
+
+  // Uncomment this to test second chance exceptions.
+  ////throw new Error("second chance");
+}
+
+function testNativeThrow() {
+  try {
+    host.throw();
+  } catch (e) {
+    host.echo(e);
+  }
+
+  // Uncomment this to test second chance exceptions.
+  ////host.throw();
+}
+
+function testScopes() {
   function deepScope() {
     let j = 42;
     j += i;
@@ -25,17 +54,10 @@ function doStuff() {
   return i;
 }
 
-function errorStuff() {
-  try {
-    throw { foo: 4, bar: [ 1, 2, 3 ] };
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
+// Run the test scenarios.
+testScriptThrow();
+testNativeThrow();
+host.echo(testScopes());
 
-var result = doStuff();
-host.echo(errorStuff());
-host.echo(result);
-
+// The exit code
 0;

--- a/lib/Debugger.Service/Service.cpp
+++ b/lib/Debugger.Service/Service.cpp
@@ -50,7 +50,8 @@ namespace JsDebug
     {
         try
         {
-            m_server.stop();
+            // Close any open connections
+            Close();
         }
         catch (...)
         {


### PR DESCRIPTION
By default exceptions that are set via `JsSetException` don't break into the debugger.  Added some test code for this behavior.

* Fixed a bug with shutdown in the error case.