### PR TITLE
Fix properties showing as `null`

### DIFF
--- a/lib/Debugger.ProtocolHandler/ProtocolHelpers.cpp
+++ b/lib/Debugger.ProtocolHandler/ProtocolHelpers.cpp
@@ -67,10 +67,12 @@ namespace JsDebug
 
         JsValueRef value = JS_INVALID_REFERENCE;
         bool hasValue = PropertyHelpers::TryGetProperty(object, PropertyHelpers::Names::Value, &value);
-        if (hasValue)
-        {
-            remoteObject->setValue(ToProtocolValue(value));
-        }
+        // TODO: Once `ToProtocolValue` is implemented uncomment the following code. VS Code prefers `value` in most
+        //       cases and prevents viewing the values of variables.
+        ////if (hasValue)
+        ////{
+        ////    remoteObject->setValue(ToProtocolValue(value));
+        ////}
 
         String display;
         bool hasDisplay = PropertyHelpers::TryGetProperty(object, PropertyHelpers::Names::Display, &display);


### PR DESCRIPTION
Stub code is returning `null` as the value for properties and VS Code
is preferring it over the description field. Comment out the code
until the rest of the implementation is complete.

Refs: https://github.com/Microsoft/ChakraCore-Debugger/issues/19