### PR TITLE
Add #ifndef WIN32_LEAN_AND_MEAN

### DIFF
--- a/lib/Debugger.ProtocolHandler/stdafx.h
+++ b/lib/Debugger.ProtocolHandler/stdafx.h
@@ -5,7 +5,9 @@
 
 #include "targetver.h"
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#endif
 
 #include <array>
 #include <cstdint>

--- a/lib/Debugger.Service/stdafx.h
+++ b/lib/Debugger.Service/stdafx.h
@@ -5,7 +5,9 @@
 
 #include "targetver.h"
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#endif
 
 // WebSocket++ generates some build warnings internally that just add noise to the build. The library author considers
 // them safe to be ignored so we'll do so here.


### PR DESCRIPTION
WIN32_LEAN_AND_MEAN may already be defined, so add #ifndef / #endif around it.

Fixes https://github.com/Microsoft/ChakraCore-Debugger/issues/36
