### PR TITLE
Ensure Windows 7 build compatibility.

### DIFF
--- a/PropertySheets/x64.props
+++ b/PropertySheets/x64.props
@@ -9,6 +9,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
+      <PreprocessorDefinitions>_WIN32_WINNT=_WIN32_WINNT_WIN7;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 

--- a/PropertySheets/x86.props
+++ b/PropertySheets/x86.props
@@ -9,7 +9,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Adjust the _WIN32_WINNT macro to support down to Windows 7.
See https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt