### PR TITLE
Add UTF-8 conversion for Windows

### DIFF
--- a/lib/Debugger.Protocol/String16.h
+++ b/lib/Debugger.Protocol/String16.h
@@ -42,6 +42,9 @@ namespace JsDebug
         size_t find(const String16& str) const;
         String16 substring(size_t pos, size_t len) const;
 
+        std::string toUtf8() const;
+        static String16 fromUtf8(const char* str, size_t length);
+
         std::string toAscii() const;
         int toInteger() const;
 


### PR DESCRIPTION
Use `MultiByteToWideChar` and `WideCharToMultiByte` on Windows to
implement UTF-8 conversion.

TODO: Support macOS/Linux as well

Fixes: https://github.com/Microsoft/ChakraCore-Debugger/issues/42
Refs: https://github.com/Microsoft/ChakraCore-Debugger/issues/18