### PR TITLE
Drop dependency on boost_system pre-built static library.

### DIFF
--- a/NuGet/Microsoft.ChakraCore.Debugger.nuspec
+++ b/NuGet/Microsoft.ChakraCore.Debugger.nuspec
@@ -15,12 +15,12 @@
     <file src="..\lib\Debugger.Service\ChakraDebugService.h" target="include" />
     <file src="..\lib\Debugger.ProtocolHandler\ChakraDebugProtocolHandler.h" target="include" />
 
-    <file src="..\build\bin\x64\Debug\*" target="lib\x64\Debug" exclude="*.ilk" />
-    <file src="..\build\bin\x64\Release\*" target="lib\x64\Release" exclude="*.ilk" />
-    <file src="..\build\bin\Win32\Debug\*" target="lib\x86\Debug" exclude="*.ilk" />
-    <file src="..\build\bin\Win32\Release\*" target="lib\x86\Release" exclude="*.ilk" />
-    <file src="..\build\bin\ARM\Debug\*" target="lib\ARM\Debug" exclude="*.ilk" />
-    <file src="..\build\bin\ARM\Release\*" target="lib\ARM\Release" exclude="*.ilk" />
+    <file src="..\build\bin\x64\Debug\*" target="lib\x64\Debug" exclude="**\*.ilk;**\*ChakraCore.dll;**\*ChakraCore.pdb" />
+    <file src="..\build\bin\x64\Release\*" target="lib\x64\Release" exclude="**\*.ilk;**\*ChakraCore.dll;**\*ChakraCore.pdb" />
+    <file src="..\build\bin\Win32\Debug\*" target="lib\x86\Debug" exclude="**\*.ilk;**\*ChakraCore.dll;**\*ChakraCore.pdb" />
+    <file src="..\build\bin\Win32\Release\*" target="lib\x86\Release" exclude="**\*.ilk;**\*ChakraCore.dll;**\*ChakraCore.pdb" />
+    <file src="..\build\bin\ARM\Debug\*" target="lib\ARM\Debug" exclude="**\*.ilk;**\*ChakraCore.dll;**\*ChakraCore.pdb" />
+    <file src="..\build\bin\ARM\Release\*" target="lib\ARM\Release" exclude="**\*.ilk;**\*ChakraCore.dll;**\*ChakraCore.pdb" />
 
     <file src="Microsoft.ChakraCore.Debugger.targets" target="build\native\" />
   </files>

--- a/PropertySheets/Chakra.Cpp.props
+++ b/PropertySheets/Chakra.Cpp.props
@@ -21,7 +21,11 @@
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        BOOST_SYSTEM_SOURCE           - Build boost::system symbols from sources (drop dependency on boost_system.lib).
+        BOOST_ERROR_CODE_HEADER_ONLY  - Compile Boost error_code members inline. Requires BOOST_SYSTEM_SOURCE.
+      -->
+      <PreprocessorDefinitions>BOOST_ERROR_CODE_HEADER_ONLY;BOOST_SYSTEM_SOURCE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp17</LanguageStandard>

--- a/bin/Debugger.Sample/ChakraCore.Debugger.Sample.vcxproj
+++ b/bin/Debugger.Sample/ChakraCore.Debugger.Sample.vcxproj
@@ -90,7 +90,6 @@
     <Import Project="..\..\packages\Microsoft.ChakraCore.vc140.1.10.2\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('..\..\packages\Microsoft.ChakraCore.vc140.1.10.2\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="..\..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="..\..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets" Condition="Exists('..\..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" />
-    <Import Project="..\..\packages\boost_system-vc141.1.68.0.0\build\boost_system-vc141.targets" Condition="Exists('..\..\packages\boost_system-vc141.1.68.0.0\build\boost_system-vc141.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -99,6 +98,5 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.ChakraCore.vc140.1.10.2\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.ChakraCore.vc140.1.10.2\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('..\..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets'))" />
-    <Error Condition="!Exists('..\..\packages\boost_system-vc141.1.68.0.0\build\boost_system-vc141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\boost_system-vc141.1.68.0.0\build\boost_system-vc141.targets'))" />
   </Target>
 </Project>

--- a/bin/Debugger.Sample/packages.config
+++ b/bin/Debugger.Sample/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="boost_date_time-vc141" version="1.68.0.0" targetFramework="native" />
-  <package id="boost_system-vc141" version="1.68.0.0" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.10.2" targetFramework="native" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
ChakraCore-Debugger as well as many Boost transitive dependents only need the `<boost/system/error_code.hpp>` members from the Boost.System code base.

This change allows to drop the NuGet `boost_system` dependency by using the `error_code` types as header-only.