### PR TITLE
Fix visibility of GetProtocolHandler()

### DIFF
--- a/test/Debugger.UnitTests/ProtocolHandler.UnitTests.cpp
+++ b/test/Debugger.UnitTests/ProtocolHandler.UnitTests.cpp
@@ -38,6 +38,7 @@ public:
         return JsRun(scriptContentValue, 0, scriptNameValue, JsParseScriptAttributeNone, result);
     }
 
+protected:
     JsRuntimeHandle GetRuntime()
     {
         return this->runtime;


### PR DESCRIPTION
Making this public allows it to build and the tests pass.