### PR TITLE
When getting scripts, ensure there's an active context

### DIFF
--- a/lib/Debugger.ProtocolHandler/Debugger.cpp
+++ b/lib/Debugger.ProtocolHandler/Debugger.cpp
@@ -98,6 +98,9 @@ namespace JsDebug
 
     std::vector<DebuggerScript> Debugger::GetScripts()
     {
+        // Ensure that there's an active context before trying to get scripts.
+        DebuggerContext::Scope debuggerScope(m_debugContext);
+        
         std::vector<DebuggerScript> scripts;
         JsValueRef scriptsArray = JS_INVALID_REFERENCE;
         JsErrorCode result = JsDiagGetScripts(&scriptsArray);

--- a/lib/Debugger.ProtocolHandler/Debugger.cpp
+++ b/lib/Debugger.ProtocolHandler/Debugger.cpp
@@ -98,9 +98,6 @@ namespace JsDebug
 
     std::vector<DebuggerScript> Debugger::GetScripts()
     {
-        // Ensure that there's an active context before trying to get scripts.
-        DebuggerContext::Scope debuggerScope(m_debugContext);
-        
         std::vector<DebuggerScript> scripts;
         JsValueRef scriptsArray = JS_INVALID_REFERENCE;
         JsErrorCode result = JsDiagGetScripts(&scriptsArray);
@@ -238,6 +235,9 @@ namespace JsDebug
         {
             return;
         }
+
+        // Ensure that there's an active context before trying to handle events.
+        DebuggerContext::Scope debuggerScope(m_debugContext);
 
         switch (debugEvent) {
         case JsDiagDebugEventSourceCompile:

--- a/lib/Debugger.ProtocolHandler/ProtocolHandler.cpp
+++ b/lib/Debugger.ProtocolHandler/ProtocolHandler.cpp
@@ -14,6 +14,7 @@ namespace JsDebug
     {
         const char c_ErrorCallbackRequired[] = "'callback' is required";
         const char c_ErrorCommandRequired[] = "'command' is required";
+        const char c_ErrorRuntimeRequired[] = "'runtime' is required";
         const char c_ErrorHandlerAlreadyConnected[] = "Handler is already connected";
         const char c_ErrorInvalidCallbackState[] = "'callbackState' can only be provided with a valid callback";
         const char c_ErrorNoHandlerConnected[] = "No handler is currently connected";
@@ -29,6 +30,10 @@ namespace JsDebug
         , m_breakOnNextLine(false)
         , m_dispatcher(this)
     {
+        if (runtime == nullptr) {
+            throw JsErrorException(JsErrorInvalidArgument, c_ErrorCallbackRequired);
+        }
+
         m_debugger = std::make_unique<Debugger>(this, runtime);
     }
 
@@ -177,6 +182,9 @@ namespace JsDebug
 
     void ProtocolHandler::ProcessCommandQueue()
     {
+        // Ensure that there's an active context before trying to process the queue.
+        DebuggerContext::Scope debuggerScope(*m_debugger->GetDebugContext());
+
         std::vector<std::pair<CommandType, std::string>> current;
 
         do


### PR DESCRIPTION
JsDiagGetScripts() will return JsNoCurrentContext if there's not an active context. Ensure there is an active context so it can return the scripts.