### PR TITLE
Changes for better VS Code compatibility - issue #60

### DIFF
--- a/lib/Debugger.Protocol/Generated/protocol/Debugger.cpp
+++ b/lib/Debugger.Protocol/Generated/protocol/Debugger.cpp
@@ -874,7 +874,7 @@ DispatchResponse::Status DispatcherImpl::setBreakpointByUrl(int callId, std::uni
         return DispatchResponse::kError;
     }
     // Declare output parameters.
-    String out_breakpointId;
+    Maybe<String> out_breakpointId;
     std::unique_ptr<protocol::Array<protocol::Debugger::Location>> out_locations;
 
     std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
@@ -883,7 +883,8 @@ DispatchResponse::Status DispatcherImpl::setBreakpointByUrl(int callId, std::uni
         return response.status();
     std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
     if (response.status() == DispatchResponse::kSuccess) {
-        result->setValue("breakpointId", ValueConversions<String>::toValue(out_breakpointId));
+        if (out_breakpointId.isJust())
+            result->setValue("breakpointId", ValueConversions<String>::toValue(out_breakpointId.fromJust()));
         result->setValue("locations", ValueConversions<protocol::Array<protocol::Debugger::Location>>::toValue(out_locations.get()));
     }
     if (weak->get())
@@ -911,7 +912,7 @@ DispatchResponse::Status DispatcherImpl::setBreakpoint(int callId, std::unique_p
         return DispatchResponse::kError;
     }
     // Declare output parameters.
-    String out_breakpointId;
+    Maybe<String> out_breakpointId;
     std::unique_ptr<protocol::Debugger::Location> out_actualLocation;
 
     std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
@@ -920,7 +921,8 @@ DispatchResponse::Status DispatcherImpl::setBreakpoint(int callId, std::unique_p
         return response.status();
     std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
     if (response.status() == DispatchResponse::kSuccess) {
-        result->setValue("breakpointId", ValueConversions<String>::toValue(out_breakpointId));
+        if (out_breakpointId.isJust())
+            result->setValue("breakpointId", ValueConversions<String>::toValue(out_breakpointId.fromJust()));
         result->setValue("actualLocation", ValueConversions<protocol::Debugger::Location>::toValue(out_actualLocation.get()));
     }
     if (weak->get())

--- a/lib/Debugger.Protocol/Generated/protocol/Debugger.h
+++ b/lib/Debugger.Protocol/Generated/protocol/Debugger.h
@@ -1122,8 +1122,8 @@ public:
     virtual DispatchResponse disable() = 0;
     virtual DispatchResponse setBreakpointsActive(bool in_active) = 0;
     virtual DispatchResponse setSkipAllPauses(bool in_skip) = 0;
-    virtual DispatchResponse setBreakpointByUrl(int in_lineNumber, Maybe<String> in_url, Maybe<String> in_urlRegex, Maybe<int> in_columnNumber, Maybe<String> in_condition, String* out_breakpointId, std::unique_ptr<protocol::Array<protocol::Debugger::Location>>* out_locations) = 0;
-    virtual DispatchResponse setBreakpoint(std::unique_ptr<protocol::Debugger::Location> in_location, Maybe<String> in_condition, String* out_breakpointId, std::unique_ptr<protocol::Debugger::Location>* out_actualLocation) = 0;
+    virtual DispatchResponse setBreakpointByUrl(int in_lineNumber, Maybe<String> in_url, Maybe<String> in_urlRegex, Maybe<int> in_columnNumber, Maybe<String> in_condition, Maybe<String>* out_breakpointId, std::unique_ptr<protocol::Array<protocol::Debugger::Location>>* out_locations) = 0;
+    virtual DispatchResponse setBreakpoint(std::unique_ptr<protocol::Debugger::Location> in_location, Maybe<String> in_condition, Maybe<String>* out_breakpointId, std::unique_ptr<protocol::Debugger::Location>* out_actualLocation) = 0;
     virtual DispatchResponse removeBreakpoint(const String& in_breakpointId) = 0;
     virtual DispatchResponse continueToLocation(std::unique_ptr<protocol::Debugger::Location> in_location) = 0;
     virtual DispatchResponse stepOver() = 0;

--- a/lib/Debugger.Protocol/js_protocol.json
+++ b/lib/Debugger.Protocol/js_protocol.json
@@ -513,7 +513,7 @@
                     { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
                 ],
                 "returns": [
-                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "breakpointId", "$ref": "BreakpointId", "optional": true, "description": "Id of the created breakpoint for further reference." },
                     { "name": "locations", "type": "array", "items": { "$ref": "Location" }, "description": "List of the locations this breakpoint resolved into upon addition." }
                 ],
                 "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
@@ -525,7 +525,7 @@
                     { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
                 ],
                 "returns": [
-                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "breakpointId", "$ref": "BreakpointId", "optional": true, "description": "Id of the created breakpoint for further reference." },
                     { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
                 ],
                 "description": "Sets JavaScript breakpoint at a given location."

--- a/lib/Debugger.ProtocolHandler/Debugger.cpp
+++ b/lib/Debugger.ProtocolHandler/Debugger.cpp
@@ -177,7 +177,7 @@ namespace JsDebug
 
     void Debugger::RemoveBreakpoint(DebuggerBreakpoint& breakpoint)
     {
-        IfJsErrorThrow(JsDiagRemoveBreakpoint(breakpoint.GetActualId()));
+        JsDiagRemoveBreakpoint(breakpoint.GetActualId());
     }
 
     JsDiagBreakOnExceptionAttributes Debugger::GetBreakOnException()
@@ -322,7 +322,7 @@ namespace JsDebug
             {
                 JsValueRef breakpoint = PropertyHelpers::GetIndexedProperty(breakpoints, index);
                 int breakpointId = PropertyHelpers::GetPropertyInt(breakpoint, PropertyHelpers::Names::BreakpointId);
-                IfJsErrorThrow(JsDiagRemoveBreakpoint(breakpointId));
+                JsDiagRemoveBreakpoint(breakpointId);
             }
         }
     }

--- a/lib/Debugger.ProtocolHandler/DebuggerImpl.h
+++ b/lib/Debugger.ProtocolHandler/DebuggerImpl.h
@@ -35,12 +35,12 @@ namespace JsDebug
             protocol::Maybe<protocol::String> in_urlRegex,
             protocol::Maybe<int> in_columnNumber,
             protocol::Maybe<protocol::String> in_condition,
-            protocol::String* out_breakpointId,
+            protocol::Maybe<protocol::String>* out_breakpointId,
             std::unique_ptr<protocol::Array<protocol::Debugger::Location>>* out_locations) override;
         protocol::Response setBreakpoint(
             std::unique_ptr<protocol::Debugger::Location> in_location,
             protocol::Maybe<protocol::String> in_condition,
-            protocol::String* out_breakpointId,
+            protocol::Maybe<protocol::String>* out_breakpointId,
             std::unique_ptr<protocol::Debugger::Location>* out_actualLocation) override;
         protocol::Response removeBreakpoint(const protocol::String& in_breakpointId) override;
         protocol::Response continueToLocation(std::unique_ptr<protocol::Debugger::Location> in_location) override;
@@ -102,6 +102,7 @@ namespace JsDebug
         SkipPauseRequest HandleBreakEvent(const DebuggerBreak& breakInfo);
 
         bool TryResolveBreakpoint(DebuggerBreakpoint& breakpoint);
+        bool ActualBreakpointIdExists(DebuggerBreakpoint& breakpoint);
 
         ProtocolHandler* m_handler;
         protocol::Debugger::Frontend m_frontend;


### PR DESCRIPTION
These address #60

1. Ignore errors on remove breakpoint (per akroshg)

2.  Don't return a breakpoint ID in the result message from "set breakpoint" calls if a breakpoint at the same resolved location actually exists.  I investigated this a bit in the VS Code node/chrome debug adapter extension, and traced the problem to an apparently undocumented feature of the inspector protocol, probably based on observed Node behavior.    See VS Code repos, .build/builtInExtensions/ms-vscode.node-debug2/node_modules/vscode-chrome-debug-core/out/src/chrome/chromeDebugAdapter.js, targetBreakpointResponsesSetResults(), where we find this comment that explains exactly what it expects:

// response.breakpointId is undefined when no target BP is backing this BP, e.g. it's at the same location
// as another BP

This change implements that by changing the breakpointId field in the set-breakpoint responses in the Debug protocol to "Maybe" strings, and then adding a check to the protocol implementation that leaves them unset when the new breakpoint turns out to match an existing breakpoint rather than creating a new one.  This does in fact make the VS Code much happier.
