### PR TITLE
Supporting conditional breakpoint.

### DIFF
--- a/lib/Debugger.ProtocolHandler/DebuggerBreak.cpp
+++ b/lib/Debugger.ProtocolHandler/DebuggerBreak.cpp
@@ -51,12 +51,23 @@ namespace JsDebug
         return Maybe<DictionaryValue>();
     }
 
+    int DebuggerBreak::GetHitBreakpoint() const
+    {
+        int breakpointId = -1;
+        if (PropertyHelpers::TryGetProperty(m_breakInfo.Get(), PropertyHelpers::Names::BreakpointId, &breakpointId))
+        {
+            return breakpointId;
+        }
+
+        return -1;
+    }
+
     Maybe<Array<String>> DebuggerBreak::GetHitBreakpoints() const
     {
         auto breakpointIds = Array<String>::create();
 
-        int breakpointId = 0;
-        if (PropertyHelpers::TryGetProperty(m_breakInfo.Get(), PropertyHelpers::Names::BreakpointId, &breakpointId))
+        int breakpointId = GetHitBreakpoint();
+        if (breakpointId >= 0)
         {
             breakpointIds->addItem(String16::fromInteger(breakpointId));
         }

--- a/lib/Debugger.ProtocolHandler/DebuggerBreak.h
+++ b/lib/Debugger.ProtocolHandler/DebuggerBreak.h
@@ -23,6 +23,9 @@ namespace JsDebug
         protocol::Maybe<protocol::Array<protocol::String>> GetHitBreakpoints() const;
         protocol::Maybe<protocol::Runtime::StackTrace> GetAsyncStackTrace() const;
 
+        // Returns -1 if no breakpoint hit.
+        int GetHitBreakpoint() const;
+
     private:
         std::unique_ptr<protocol::Runtime::RemoteObject> GetException() const;
 

--- a/lib/Debugger.ProtocolHandler/DebuggerImpl.cpp
+++ b/lib/Debugger.ProtocolHandler/DebuggerImpl.cpp
@@ -505,12 +505,7 @@ namespace JsDebug
                 if (JsCreateStringUtf16(condition.characters16(), condition.length(), &expressionStr) == JsNoError)
                 {
                     JsValueRef evalResult = JS_INVALID_REFERENCE;
-                    JsErrorCode err = JsDiagEvaluate(
-                        expressionStr,
-                        0,
-                        JsParseScriptAttributeNone,
-                        true,
-                        &evalResult);
+                    JsErrorCode err = JsDiagEvaluate(expressionStr, 0, JsParseScriptAttributeNone, true, &evalResult);
 
                     // If the condition is provided, the debugger will stop only when the expression is evaluated to true
                     if (err == JsNoError && PropertyHelpers::GetPropertyBoolConvert(evalResult, PropertyHelpers::Names::Value))

--- a/lib/Debugger.ProtocolHandler/DebuggerImpl.h
+++ b/lib/Debugger.ProtocolHandler/DebuggerImpl.h
@@ -102,6 +102,7 @@ namespace JsDebug
         SkipPauseRequest HandleBreakEvent(const DebuggerBreak& breakInfo);
 
         bool TryResolveBreakpoint(DebuggerBreakpoint& breakpoint);
+        SkipPauseRequest EvaluateConditionOnBreakpoint(int bpId);
 
         ProtocolHandler* m_handler;
         protocol::Debugger::Frontend m_frontend;


### PR DESCRIPTION
Condition expression are supported now. On break the conditional expression will be evaluated and debugger will break on that breakpoint when that condition returns true.