### PR TITLE
office build fixes

### DIFF
--- a/lib/Debugger.ProtocolHandler/ConsoleHandler.cpp
+++ b/lib/Debugger.ProtocolHandler/ConsoleHandler.cpp
@@ -30,6 +30,9 @@ namespace JsDebug
         JsValueRef undefinedValue = JS_INVALID_REFERENCE;
         IfJsErrorThrow(JsGetUndefinedValue(&undefinedValue));
         return undefinedValue;
+
+        UNREFERENCED_PARAMETER(callee);
+        UNREFERENCED_PARAMETER(isConstructCall);
     }
 
     JsValueRef CALLBACK ConsoleLog(


### PR DESCRIPTION
In office build environment, unused parameter warning is treated as error (https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4100?view=vs-2019). This PR is to fix that.