### PR TITLE
do not use SolutionDir for project include paths

### DIFF
--- a/ChakraCore.Debugger.sln
+++ b/ChakraCore.Debugger.sln
@@ -35,14 +35,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{AAF5848E-B
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChakraCore.Debugger.UnitTests", "test\Debugger.UnitTests\ChakraCore.Debugger.UnitTests.vcxproj", "{31A9E08C-8DCA-4B59-B79F-E3CB686495EA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1E5CC105-78BE-4E61-9B02-D6E3780D121F}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Debug|ARM = Debug|ARM
+		Release|ARM = Release|ARM
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-		Release|ARM = Release|ARM
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AC43259C-97CB-43C1-9B56-983CA31ED5D2}.Debug|ARM.ActiveCfg = Debug|ARM

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)</SolutionDir>
     <WindowsSDKDesktopARMSupport Condition="'$(Platform)'=='ARM'">true</WindowsSDKDesktopARMSupport>
-    <DepsDirectoryPath>$(MSBuildThisFileDirectory)deps\</DepsDirectoryPath>
+    <ChakraCoreDebuggerDir>$(MSBuildThisFileDirectory)</ChakraCoreDebuggerDir>
+    <ChakraCoreDebuggerDepsDir>$(MSBuildThisFileDirectory)deps\</ChakraCoreDebuggerDepsDir>
     <OutDir>$(MSBuildThisFileDirectory)build\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(MSBuildThisFileDirectory)build\obj\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</IntDir>
   </PropertyGroup>

--- a/bin/Debugger.Sample/ChakraCore.Debugger.Sample.vcxproj
+++ b/bin/Debugger.Sample/ChakraCore.Debugger.Sample.vcxproj
@@ -34,7 +34,7 @@
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(SolutionDir)PropertySheets\Chakra.Cpp.props" />
+  <Import Project="$(ProjectDir)..\..\PropertySheets\Chakra.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/bin/Debugger.Sample/ChakraCore.Debugger.Sample.vcxproj
+++ b/bin/Debugger.Sample/ChakraCore.Debugger.Sample.vcxproj
@@ -48,7 +48,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)lib\Debugger.ProtocolHandler;$(SolutionDir)lib\Debugger.Service;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ChakraCoreDebuggerDir)lib\Debugger.ProtocolHandler;$(ChakraCoreDebuggerDir)lib\Debugger.Service;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/lib/Debugger.Protocol/ChakraCore.Debugger.Protocol.vcxproj
+++ b/lib/Debugger.Protocol/ChakraCore.Debugger.Protocol.vcxproj
@@ -34,7 +34,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(SolutionDir)PropertySheets\Chakra.Cpp.props" />
+  <Import Project="$(ProjectDir)..\..\PropertySheets\Chakra.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/lib/Debugger.ProtocolHandler/ChakraCore.Debugger.ProtocolHandler.vcxproj
+++ b/lib/Debugger.ProtocolHandler/ChakraCore.Debugger.ProtocolHandler.vcxproj
@@ -48,7 +48,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)lib\Debugger.Protocol;$(SolutionDir)lib\Debugger.Protocol\Generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ChakraCoreDebuggerDir)lib\Debugger.Protocol;$(ChakraCoreDebuggerDir)lib\Debugger.Protocol\Generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/lib/Debugger.ProtocolHandler/ChakraCore.Debugger.ProtocolHandler.vcxproj
+++ b/lib/Debugger.ProtocolHandler/ChakraCore.Debugger.ProtocolHandler.vcxproj
@@ -34,7 +34,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(SolutionDir)PropertySheets\Chakra.Cpp.props" />
+  <Import Project="$(ProjectDir)..\..\PropertySheets\Chakra.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/lib/Debugger.Service/ChakraCore.Debugger.Service.vcxproj
+++ b/lib/Debugger.Service/ChakraCore.Debugger.Service.vcxproj
@@ -48,7 +48,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PreprocessorDefinitions>_HAS_AUTO_PTR_ETC;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)lib\Debugger.ProtocolHandler;$(DepsDirectoryPath)websocketpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ChakraCoreDebuggerDir)lib\Debugger.ProtocolHandler;$(ChakraCoreDebuggerDepsDir)websocketpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -67,7 +67,7 @@
   <ItemDefinitionGroup Condition="'$(Platform)'=='ARM'">
     <ClCompile>
       <PreprocessorDefinitions>ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(DepsDirectoryPath)asio\asio\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ChakraCoreDebuggerDepsDir)asio\asio\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/lib/Debugger.Service/ChakraCore.Debugger.Service.vcxproj
+++ b/lib/Debugger.Service/ChakraCore.Debugger.Service.vcxproj
@@ -34,7 +34,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(SolutionDir)PropertySheets\Chakra.Cpp.props" />
+  <Import Project="$(ProjectDir)..\..\PropertySheets\Chakra.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/test/Debugger.UnitTests/ChakraCore.Debugger.UnitTests.vcxproj
+++ b/test/Debugger.UnitTests/ChakraCore.Debugger.UnitTests.vcxproj
@@ -34,7 +34,7 @@
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(SolutionDir)PropertySheets\Chakra.Cpp.props" />
+  <Import Project="$(ProjectDir)..\..\PropertySheets\Chakra.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/test/Debugger.UnitTests/ChakraCore.Debugger.UnitTests.vcxproj
+++ b/test/Debugger.UnitTests/ChakraCore.Debugger.UnitTests.vcxproj
@@ -48,7 +48,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)lib\Debugger.ProtocolHandler;$(DepsDirectoryPath)Catch2\single_include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ChakraCoreDebuggerDir)lib\Debugger.ProtocolHandler;$(ChakraCoreDebuggerDepsDir)Catch2\single_include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Use $(ChakraCoreDebuggerDir) instead of $(SolutionDir) for include paths.
Rename $(DepsDirectoryPath) to $(ChakraCoreDebuggerDepsDir) for the deps subdirectory.

This allows the projects to be used in other solutions, because the include paths do not
depend upon the solution directory.