### PR TITLE
Updated SDK and toolset versions.

### DIFF
--- a/ChakraCore.Debugger.sln
+++ b/ChakraCore.Debugger.sln
@@ -42,12 +42,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|ARM = Release|ARM
+		Debug|ARM = Debug|ARM
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+		Release|ARM = Release|ARM
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AC43259C-97CB-43C1-9B56-983CA31ED5D2}.Debug|ARM.ActiveCfg = Debug|ARM

--- a/NuGet/Microsoft.ChakraCore.Debugger.nuspec
+++ b/NuGet/Microsoft.ChakraCore.Debugger.nuspec
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Sample usage:
+  nuget.exe pack Microsoft.ChakraCore.Debugger.nuspec -Properties "id=some_id" -Version "some_version"
+-->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>Microsoft.ChakraCore.Debugger</id>
+    <id>$id$</id>
     <version>$version$</version>
     <description>Debugging companion library for the ChakraCore JavaScript engine.</description>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/Microsoft/ChakraCore-Debugger</projectUrl>
     <licenseUrl>https://github.com/Microsoft/ChakraCore-Debugger/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>Copyright © 2018 Microsoft</copyright>
+    <copyright>Copyright © 2019 Microsoft</copyright>
   </metadata>
 
   <files>
@@ -22,6 +27,6 @@
     <file src="..\build\bin\ARM\Debug\*" target="lib\ARM\Debug" exclude="**\*.ilk;**\*ChakraCore.dll;**\*ChakraCore.pdb" />
     <file src="..\build\bin\ARM\Release\*" target="lib\ARM\Release" exclude="**\*.ilk;**\*ChakraCore.dll;**\*ChakraCore.pdb" />
 
-    <file src="Microsoft.ChakraCore.Debugger.targets" target="build\native\" />
+    <file src="Microsoft.ChakraCore.Debugger.targets" target="build\native\$id$.targets" />
   </files>
 </package>

--- a/PropertySheets/Chakra.Cpp.props
+++ b/PropertySheets/Chakra.Cpp.props
@@ -4,11 +4,11 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 


### PR DESCRIPTION
- Allows setting the NuGet ID dynamically.
- Updates Windows SDK version.
- Uses default VC toolset versions for  VS 2017 and VS 2019.
- Defaults build platform to x64.