### PR TITLE
Use x86 binaries when consuming from ARM64.

### DIFF
--- a/NuGet/Microsoft.ChakraCore.Debugger.targets
+++ b/NuGet/Microsoft.ChakraCore.Debugger.targets
@@ -10,7 +10,7 @@
       <AdditionalLibraryDirectories Condition="'$(Platform)' != 'Win32'">
         $(MSBuildThisFileDirectory)..\..\lib\$(Platform)\$(Configuration);%(AdditionalLibraryDirectories)
       </AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'Win32'">
+      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'Win32' OR '$(Platform)' == 'ARM64'">
         $(MSBuildThisFileDirectory)..\..\lib\x86\$(Configuration);%(AdditionalLibraryDirectories)
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>ChakraCore.Debugger.Protocol.lib;ChakraCore.Debugger.ProtocolHandler.lib;ChakraCore.Debugger.Service.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Allow usage from `ARM64`-enabled projects.
This will import `x86` artifacts, which should be ABI safe.